### PR TITLE
Improve lager_syslog_backend to support non-atom output log levels.

### DIFF
--- a/src/lager_syslog_backend.erl
+++ b/src/lager_syslog_backend.erl
@@ -40,9 +40,9 @@
 
 
 %% @private
-init([Ident, Facility, Level]) when is_atom(Level) ->
+init([Ident, Facility, Level]) ->
     init([Ident, Facility, Level, {lager_default_formatter, ?DEFAULT_FORMAT}]);
-init([Ident, Facility, Level, {Formatter, FormatterConfig}]) when is_atom(Level), is_atom(Formatter) ->
+init([Ident, Facility, Level, {Formatter, FormatterConfig}]) when is_atom(Formatter) ->
     case application:start(syslog) of
         ok ->
             init2([Ident, Facility, Level, {Formatter, FormatterConfig}]);


### PR DESCRIPTION
This supports forms such as "!notice" for configuring the output
log level (using the config handling changes from 7aa316902e2d in
lager).
