### PR TITLE
Update rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-       {lager, "(2.0|1.0|1.2).*", {git, "git://github.com/basho/lager", {branch, "master"}}},
+       {lager, "(2.1|2.0|1.0|1.2).*", {git, "git://github.com/basho/lager", {branch, "master"}}},
        {'syslog', "1.0.*", {git, "git://github.com/Vagabond/erlang-syslog", {branch, "master"}}}
        ]
 }.


### PR DESCRIPTION
So we don't fail on lager 2.1.x installs.