### PR TITLE
Update lager

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_enabled, true}.
 
 {deps, [
-       {lager, {git, "git://github.com/erlang-lager/lager.git", {tag, "3.6.4"}}},
+       {lager, {git, "git://github.com/erlang-lager/lager.git", {tag, "3.8.0"}}},
        {syslog, {git, "git://github.com/Vagabond/erlang-syslog", {tag, "1.0.5"}}}
        ]
 }.

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,7 +2,7 @@
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,
   {git,"git://github.com/erlang-lager/lager.git",
-       {ref,"bf60290101306b3cc26544d0d181a5cff8931e82"}},
+       {ref,"22e62f28e5afabe90a6f31bcde367a2b5799fc94"}},
   0},
  {<<"syslog">>,
   {git,"git://github.com/Vagabond/erlang-syslog",


### PR DESCRIPTION
Older lager versions have an error in their rebar.config that causes to pick up the wrong OTP release